### PR TITLE
Added PORT to run across platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 React/Redux `dataportal` skeleton
 
+Set the environment variables:
+Create a ```.env``` file in the project directory containing 
+
+```
+PORT=80
+```
+
 Start in Debug Mode:
 ```
 npm install

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-scripts": "1.0.7"
   },
   "scripts": {
-    "start": "PORT=80 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",


### PR DESCRIPTION
line 71 in package.json 
` "start": "PORT=80 react-scripts start",` 
has Unix kind of syntax (causes problems in Windows). Fixed it by introducing a `.env` file  containing the PORT value. Also updated the Readme.MD