### PR TITLE
Update copyright year in footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -4,7 +4,7 @@ class Footer extends Component {
   render() {
     return (
       <footer className="app-footer">
-        <a href="https://teamdigitale.governo.it">Team Digitale</a> &copy; 2017 Team Digitale.
+        <a href="https://teamdigitale.governo.it">Team Digitale</a> &copy; 2017-2018 Team Digitale.
         <span className="float-right">Powered by <a href="https://teamdigitale.governo.it">Team Digitale</a></span>
       </footer>
     )


### PR DESCRIPTION
As of now, 2017 is displayed in the footer copyright notice. This pull request is purely cosmetic as it updates it to 2017-2018 to make it look fresher.

(IMHO the entire copyright notice should be removed, as it's misleading since it does _not_ apply to the page contents but only to the layout. Shouldn't we generate a dynamic copyright notice according to the contents?)